### PR TITLE
updated gretty-plugin.html to the latest version of gretty 0.0.13

### DIFF
--- a/plugins/gretty-plugin.html
+++ b/plugins/gretty-plugin.html
@@ -53,7 +53,7 @@ Advanced gradle plugin for running web-apps on jetty-7/servlet-API-2.5, jetty-8/
             </tr>
             <tr>
                 <th>Version</th>
-                <td>0.0.12</td>
+                <td>0.0.13</td>
             </tr>
             </tbody>
         </table>
@@ -66,7 +66,7 @@ Advanced gradle plugin for running web-apps on jetty-7/servlet-API-2.5, jetty-8/
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'org.akhikhl.gretty:gretty-plugin:0.0.12'
+        classpath 'org.akhikhl.gretty:gretty-plugin:0.0.13'
     }
 }
 


### PR DESCRIPTION
Only version upgrade. And yes, now gretty is on jcenter.
